### PR TITLE
Add Rugspull

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python/).
   * [SDK](#sdk)
   * [Tools](#tools)
   * [Analytics](#analytics)
+  * [DApps](#dapps)
 - [opBNB](#opbnb)
   * [Tools](#tools)
   * [Analytics](#analytics)
@@ -44,6 +45,12 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python/).
 * [Defistation](https://www.defistation.io/)
 * [Bitquery](https://bitquery.io/blog/binance-smart-chain-api)
 * [DeBank](https://debank.com/projects?type=bsc)
+
+### DApps
+
+Applications deployed on BNB Smart Chain.
+
+* [Rugspull](https://rugspull.com/): A high-risk BNB Chain parody protocol with an internal WBNB AMM, one disclosed all-at-once founder-token sale path, and public exact-match source.
 
 ## opBNB
 


### PR DESCRIPTION
Adds one BNB Smart Chain dapp entry and introduces a DApps subsection.

Why it is useful: Rugspull turns a founder-exit mechanism into explicit, inspectable rules: an internal canonical WBNB AMM, no reserve-withdraw function, and one all-at-once protocol-held founder-allocation sale path after lock. The deployed BSC contracts have public exact-match source and project-authored tests.

Review boundary: this is a high-risk parody protocol, not a safety claim or promise of returns. Total loss remains possible and an independent audit is still pending.
